### PR TITLE
chore: add commonKeywords to yaml spec and LibrarySpec

### DIFF
--- a/src/main/generators/LibraryGenerator.ts
+++ b/src/main/generators/LibraryGenerator.ts
@@ -16,7 +16,7 @@ export class LibraryGenerator {
             moduleName: [this.librarySpec.displayName, mspec.moduleName].join(' / '),
             version: '0.0.0',
             description: mspec.description,
-            keywords: [],
+            keywords: [...(this.librarySpec.commonKeywords || [])],
             cacheMode: 'always',
             evalMode: 'manual',
             params: this.generateParamDefs(mspec),

--- a/src/main/schema/LibrarySpec.ts
+++ b/src/main/schema/LibrarySpec.ts
@@ -10,6 +10,7 @@ export interface LibrarySpec {
     baseUrl: string;
     description: string;
     commonParams?: LibraryParamSpec[];
+    commonKeywords?: string[];
     auth?: {
         name: string;
         in: 'header' | 'query';
@@ -33,6 +34,11 @@ export const LibrarySpecSchema = new Schema<LibrarySpec>({
         commonParams: {
             type: 'array',
             items: LibraryParamSpecSchema.schema,
+            optional: true,
+        },
+        commonKeywords: {
+            type: 'array',
+            items: { type: 'string' },
             optional: true,
         },
         auth: {


### PR DESCRIPTION
/ https://github.com/ubio/squad-nodescript/issues/1066

Adds `commonKeywords` to facilitate finding libraries that may not be obvious to some users.

E.g. 
Library Name: "Anthropic"
User is looking for: "Claude"

Adding `commonKeywords` can help with UX
